### PR TITLE
refactor: editor.js のインライン重複関数を frontmatter_template.js からの import に置き換える

### DIFF
--- a/docs/dictionary.md
+++ b/docs/dictionary.md
@@ -356,7 +356,6 @@ en: HotReload
 - `references`: [テンプレートマッチャー](#テンプレートマッチャー) — マッチャーとインジェクターを合成する
 - `references`: [テンプレートインジェクター](#テンプレートインジェクター)
 **src:** `packages/editor/js/frontmatter_template.js` `loadFrontmatterTemplate(filePath, templates)`
-**注記:** `packages/editor/js/editor.js` にブラウザ環境用のインライン実装が存在する（ESモジュール import 不可のため）。変更時は両方に同じ修正を適用すること。
 
 ---
 
@@ -367,7 +366,6 @@ en: HotReload
 - `references`: [テンプレート設定](#テンプレート設定) — テンプレート設定を参照する
 - `references`: [フロントマターテンプレート](#フロントマターテンプレート) — マッチしたテンプレートを返す
 **src:** `packages/editor/js/frontmatter_template.js` `matchTemplate(filePath, templates)`
-**注記:** `packages/editor/js/editor.js` にブラウザ環境用のインライン実装が存在する（ESモジュール import 不可のため）。変更時は両方に同じ修正を適用すること。
 
 ---
 
@@ -387,7 +385,6 @@ en: HotReload
 **関係:**
 - `references`: [フロントマターテンプレート](#フロントマターテンプレート) — テンプレートを受け取りフロントマター文字列を生成する
 **src:** `packages/editor/js/frontmatter_template.js` `buildFrontmatterString(template, baseName)`
-**注記:** `packages/editor/js/editor.js` にブラウザ環境用のインライン実装が存在する（ESモジュール import 不可のため）。変更時は両方に同じ修正を適用すること。
 
 ---
 

--- a/packages/editor/js/editor.js
+++ b/packages/editor/js/editor.js
@@ -1,39 +1,7 @@
 import { initAutoPreview } from './autoPreviewInitializer.js'
+import { matchTemplate, buildFrontmatterString, loadFrontmatterTemplate } from './frontmatter_template.js'
 
 const sleep = waitTime => new Promise( resolve => setTimeout(resolve, waitTime) );
-
-// @vocab: テンプレートマッチャー (docs/dictionary.md#テンプレートマッチャー)
-// @test: tests/editor/editor-frontmatter-template.test.js
-const matchTemplate = (filePath, templates) => {
-  if (!filePath || !templates || templates.length === 0) return null
-  let best = null
-  for (const tmpl of templates) {
-    if (filePath.startsWith(tmpl.path_prefix)) {
-      if (!best || tmpl.path_prefix.length > best.path_prefix.length) {
-        best = tmpl
-      }
-    }
-  }
-  return best
-}
-
-// @vocab: テンプレートインジェクター (docs/dictionary.md#テンプレートインジェクター)
-// @test: tests/editor/editor-frontmatter-template.test.js
-const buildFrontmatterString = (template, baseName) => {
-  const fields = { ...template.fields }
-  fields.title = baseName
-  const lines = Object.entries(fields).map(([key, value]) => `${key}: ${value}`)
-  return `---\n${lines.join('\n')}\n---\n`
-}
-
-// @vocab: フロントマターテンプレートローダー (docs/dictionary.md#フロントマターテンプレートローダー)
-// @test: tests/editor/editor-frontmatter-template.test.js
-const loadFrontmatterTemplate = (filePath, templates) => {
-  const matched = matchTemplate(filePath, templates)
-  if (!matched) return null
-  const baseName = filePath.split('/').pop().replace(/\.[^.]+$/, '')
-  return buildFrontmatterString(matched, baseName)
-}
 
 // @vocab: テンプレートレゾルバー (docs/dictionary.md#テンプレートレゾルバー)
 // @test: tests/editor/editor-frontmatter-template.test.js


### PR DESCRIPTION
そもそも不要だったコピーを削除し、テストの偽陰性をなくす。